### PR TITLE
added trust of linked hc and holochain binaries

### DIFF
--- a/entitlements.mac.plist
+++ b/entitlements.mac.plist
@@ -12,5 +12,7 @@
     <true/>
     <key>com.apple.security.files.all</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
macos code signing not working without entitlement of dependency libs/binaries