### PR TITLE
dylibs couldn't be signed so were breaking macos gatekeeper

### DIFF
--- a/entitlements.mac.plist
+++ b/entitlements.mac.plist
@@ -10,9 +10,7 @@
     <true/>
     <key>com.apple.security.network.client</key>
     <true/>
-    <key>com.apple.security.files.all</key>
-    <true/>
-    <key>com.apple.security.cs.disable-library-validation</key>
+    <key>com.apple.security.files.user-selected.read-write</key>
     <true/>
   </dict>
 </plist>


### PR DESCRIPTION
This achieves fully validated/validatable release packages for Mac!

switched to more minimal entitelment for file system access
https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_files_user-selected_read-write

This came from the signed and notarized build complaining:
"not valid for use in process using Library Validation: mapped file has no cdhash, completely unsigned? Code has to be at least ad-hoc signed."


My best lead was here
find libraries a binary was linked against
https://superuser.com/questions/239590/find-libraries-a-binary-was-linked-against
http://thecourtsofchaos.com/2013/09/16/how-to-copy-and-relink-binaries-on-osx/


Followup... this could also just help us with the nix-shell versions of `hc` and `holochain` which are linked against this, for example:
/nix/store/wr2qhq0z8nfq6bng1nvs0hbpzbx2s9v5-bash-interactive-4.4-p23/bin/bash