### PR TITLE
release 0.3.5 with new dna (0.3.6) and ui (0.3.11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ It needs to know which versions you want to be running or packaging.
 
 #### acorn-hc
 
-You can pass in a version number of an [acorn-hc](https://github.com/h-be/acorn-hc) release, like 0.3.4
+You can pass in a version number of an [acorn-hc](https://github.com/h-be/acorn-hc) release, like 0.3.6
 
 ```bash
 nix-shell --run 'acorn-bundle-dna x.y.z'
@@ -50,7 +50,7 @@ This will result in there being
 
 #### acorn-ui
 
-You can pass in a version number of an [acorn-ui](https://github.com/h-be/acorn-ui) release, like 0.3.5
+You can pass in a version number of an [acorn-ui](https://github.com/h-be/acorn-ui) release, like 0.3.11
 
 Just run
 

--- a/config.nix
+++ b/config.nix
@@ -68,8 +68,8 @@ echo "All finished!!!"
   # the previous version will be scanned/bumped by release scripts
   # the current version is what the release scripts bump *to*
   version = {
-   current = "0.3.4";
-   previous = "0.3.3";
+   current = "0.3.5";
+   previous = "0.3.4";
   };
 
   github = {

--- a/nix/acorn/default.nix
+++ b/nix/acorn/default.nix
@@ -3,11 +3,11 @@ let
  bundle-dna = (pkgs.writeShellScriptBin "acorn-bundle-dna" ''
   rm -rf dna
   # an optional first argument should be the version number you want
-  # default to 0.3.5
-  echo "fetching DNA from https://github.com/h-be/acorn-hc/releases/download/v''${1:-0.3.5}/profiles.dna.json"
-  echo "fetching DNA from https://github.com/h-be/acorn-hc/releases/download/v''${1:-0.3.5}/projects.dna.json"
-  curl -O -L https://github.com/h-be/acorn-hc/releases/download/v''${1:-0.3.5}/profiles.dna.json
-  curl -O -L https://github.com/h-be/acorn-hc/releases/download/v''${1:-0.3.5}/projects.dna.json
+  # default to 0.3.6
+  echo "fetching DNA from https://github.com/h-be/acorn-hc/releases/download/v''${1:-0.3.6}/profiles.dna.json"
+  echo "fetching DNA from https://github.com/h-be/acorn-hc/releases/download/v''${1:-0.3.6}/projects.dna.json"
+  curl -O -L https://github.com/h-be/acorn-hc/releases/download/v''${1:-0.3.6}/profiles.dna.json
+  curl -O -L https://github.com/h-be/acorn-hc/releases/download/v''${1:-0.3.6}/projects.dna.json
   mkdir dna
   mv profiles.dna.json dna/profiles.dna.json
   mv projects.dna.json dna/projects.dna.json
@@ -21,8 +21,8 @@ let
   rm -rf ui
   mkdir ui
   # an optional first argument should be the version number you want
-  # default to 0.3.10
-  curl -O -L https://github.com/h-be/acorn-ui/releases/download/v''${1:-0.3.10}/acorn-ui.zip
+  # default to 0.3.11
+  curl -O -L https://github.com/h-be/acorn-ui/releases/download/v''${1:-0.3.11}/acorn-ui.zip
   # unzip into the ./ui folder
   unzip acorn-ui.zip -d ui
   rm acorn-ui.zip

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Acorn",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Acorn",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A Holochain State of Affairs Tree application",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
This is because of 2 issues, one in acorn-hc and one in acorn-ui
- signals had suffered a breaking change, https://github.com/h-be/acorn-ui/pull/159
- edge had no unqiueness and thus could only exist once (and not be deleted/recreated) https://github.com/h-be/acorn-hc/pull/100